### PR TITLE
Add selected batch 4 assets

### DIFF
--- a/tokenlist.json
+++ b/tokenlist.json
@@ -9124,28 +9124,6 @@
         },
         {
             "chainId": 1,
-            "address": "0x94912D9f8ef1108CA605A6F5331a0dA0294Adfe0",
-            "name": "ASE Technology Holding (Ondo Tokenized)",
-            "symbol": "ASXon",
-            "decimals": 18,
-            "logoURI": "https://cdn.ondo.finance/tokens/logos/asxon_160x160.png",
-            "tags": [
-                "ondo"
-            ]
-        },
-        {
-            "chainId": 56,
-            "address": "0xB695fAe94eBCA7b873aB139856CeebC68C5098CE",
-            "name": "ASE Technology Holding (Ondo Tokenized)",
-            "symbol": "ASXon",
-            "decimals": 18,
-            "logoURI": "https://cdn.ondo.finance/tokens/logos/asxon_160x160.png",
-            "tags": [
-                "ondo"
-            ]
-        },
-        {
-            "chainId": 1,
             "address": "0xdB5a8f5B4C17f2Ee2e7192A150687E48eB3C415d",
             "name": "Roundhill Memory ETF (Ondo Tokenized)",
             "symbol": "DRAMon",

--- a/tokenlist.json
+++ b/tokenlist.json
@@ -1,6 +1,6 @@
 {
     "name": "Ondo Tokenized Stocks List",
-    "timestamp": "2026-06-10T23:28:40.907816Z",
+    "timestamp": "2026-06-10T23:38:28.069815Z",
     "version": {
         "major": 8,
         "minor": 0,
@@ -9646,6 +9646,28 @@
             "symbol": "YEARon",
             "decimals": 18,
             "logoURI": "https://cdn.ondo.finance/tokens/logos/yearon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x141196732cE4BB20010E4149704C0F278d5d3CEA",
+            "name": "Strive Preferred (Ondo Tokenized)",
+            "symbol": "SATAon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/sataon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x732823512Ba98D1BCDE471ca023ee2A0C9f117b7",
+            "name": "Strive Preferred (Ondo Tokenized)",
+            "symbol": "SATAon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/sataon_160x160.png",
             "tags": [
                 "ondo"
             ]

--- a/tokenlist.json
+++ b/tokenlist.json
@@ -1,8 +1,8 @@
 {
     "name": "Ondo Tokenized Stocks List",
-    "timestamp": "2026-03-10T22:09:57.000000Z",
+    "timestamp": "2026-06-10T23:28:40.907816Z",
     "version": {
-        "major": 6,
+        "major": 8,
         "minor": 0,
         "patch": 0
     },
@@ -2248,15 +2248,15 @@
             ]
         },
         {
-          "chainId": 1,
-          "address": "0xECABE1Ff8a9e1dC55899cf58dac8497ecE5Ae84c",
-          "name": "Strategy Stretch Preferred (Ondo Tokenized)",
-          "symbol": "STRCon",
-          "decimals": 18,
-          "logoURI": "https://cdn.ondo.finance/tokens/logos/strcon_160x160.png",
-          "tags": [
-              "ondo"
-          ]
+            "chainId": 1,
+            "address": "0xECABE1Ff8a9e1dC55899cf58dac8497ecE5Ae84c",
+            "name": "Strategy Stretch Preferred (Ondo Tokenized)",
+            "symbol": "STRCon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/strcon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
         },
         {
             "chainId": 56,
@@ -5834,15 +5834,3843 @@
             ]
         },
         {
-          "chainId": 56,
-          "address": "0x71E9dc9DEbc18650BD2342B93623B88C2aD00c89",
-          "name": "Strategy Stretch Preferred (Ondo Tokenized)",
-          "symbol": "STRCon",
-          "decimals": 18,
-          "logoURI": "https://cdn.ondo.finance/tokens/logos/strcon_160x160.png",
-          "tags": [
-              "ondo"
-          ]
+            "chainId": 56,
+            "address": "0x71E9dc9DEbc18650BD2342B93623B88C2aD00c89",
+            "name": "Strategy Stretch Preferred (Ondo Tokenized)",
+            "symbol": "STRCon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/strcon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xE45575b8895664DEdf7bEfFEe98b078F2Cf1A192",
+            "name": "Corning (Ondo Tokenized)",
+            "symbol": "GLWon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/glwon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x25a4DbAE9a0Cd8C75656D6b50FFDf4900CC20d8f",
+            "name": "Corning (Ondo Tokenized)",
+            "symbol": "GLWon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/glwon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xbF5ab848efff75D897a3DBE4647B939C59D3cdb0",
+            "name": "Lumentum Holdings (Ondo Tokenized)",
+            "symbol": "LITEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/liteon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x0fAcaFB97ffDbA3cAe88512070AF49bd30674cD9",
+            "name": "Lumentum Holdings (Ondo Tokenized)",
+            "symbol": "LITEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/liteon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x99888f2CCD08258eD5F66e94bA59d7E75016900F",
+            "name": "Applied Optoelectronics (Ondo Tokenized)",
+            "symbol": "AAOIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aaoion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x149Bda9e7251DC36f536d1fE7F92A5ea203F4F3D",
+            "name": "Applied Optoelectronics (Ondo Tokenized)",
+            "symbol": "AAOIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aaoion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x6a3E77d984e22bed6A036D3DA79D7857936a593f",
+            "name": "AXT (Ondo Tokenized)",
+            "symbol": "AXTIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/axtion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x0C50323AF81D5C33822c6Add256Fb9093D42BC74",
+            "name": "AXT (Ondo Tokenized)",
+            "symbol": "AXTIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/axtion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x38cBBBF83Ab583E231960B5c112145324Bef55ae",
+            "name": "nVent Electric (Ondo Tokenized)",
+            "symbol": "NVTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/nvton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x484Ce83BB55b50D70236C7D1E29E0Ba7524f905B",
+            "name": "nVent Electric (Ondo Tokenized)",
+            "symbol": "NVTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/nvton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x62D5854E309E7F7fC27ff6EbEfb54D2b235A0E9B",
+            "name": "nLIGHT (Ondo Tokenized)",
+            "symbol": "LASRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/lasron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x476a2caD3197Df68186b61bC36296E8d3d2d1b85",
+            "name": "nLIGHT (Ondo Tokenized)",
+            "symbol": "LASRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/lasron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x6401365aA495ca96Bcfcf9c6c47Bd4a590336b00",
+            "name": "FormFactor (Ondo Tokenized)",
+            "symbol": "FORMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/formon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xD678F3F86436Ee298d28A3C414c367aDFeD65337",
+            "name": "FormFactor (Ondo Tokenized)",
+            "symbol": "FORMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/formon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xDc4F9c9CAa96046816255Bc6c10fd6433863128E",
+            "name": "MKS Inc. (Ondo Tokenized)",
+            "symbol": "MKSIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/mksion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xd41699aA1BfC1c5f172c27f387372bd30717a5db",
+            "name": "MKS Inc. (Ondo Tokenized)",
+            "symbol": "MKSIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/mksion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xdFCa97fB2A3163011f3b5B3198F63D9Ab8F04A98",
+            "name": "Ichor Holdings (Ondo Tokenized)",
+            "symbol": "ICHRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ichron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xFb836dc42EBDfF6aA8DB9339336899061D1C4f3F",
+            "name": "Ichor Holdings (Ondo Tokenized)",
+            "symbol": "ICHRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ichron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xeB48e68F01c0C76735dc6F1dcC0F151A973BD9d2",
+            "name": "Aehr Test Systems (Ondo Tokenized)",
+            "symbol": "AEHRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aehron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xdCE0957E22F7baf2AA1a50d854e03cEe6f215004",
+            "name": "Aehr Test Systems (Ondo Tokenized)",
+            "symbol": "AEHRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aehron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xC087EA645a1eFE021577c19413FBE39d617A3196",
+            "name": "Camtek (Ondo Tokenized)",
+            "symbol": "CAMTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/camton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xc2f65e745Fd13af1d00d5c81dD33F762FB81C264",
+            "name": "Camtek (Ondo Tokenized)",
+            "symbol": "CAMTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/camton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x995584539633F7d28757B6329A42439BD8aeCEde",
+            "name": "Wolfspeed (Ondo Tokenized)",
+            "symbol": "WOLFon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/wolfon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x55b56CC2cdcbC2C58668F72663bE7599a46Ed79F",
+            "name": "Wolfspeed (Ondo Tokenized)",
+            "symbol": "WOLFon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/wolfon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xE172Fb6B867F873Db7Cb2D7435B95a07e5deFE81",
+            "name": "Power Integrations (Ondo Tokenized)",
+            "symbol": "POWIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/powion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x5417b7CFDb8a187004067297EbF1491c8D6D5C09",
+            "name": "Power Integrations (Ondo Tokenized)",
+            "symbol": "POWIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/powion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x7C17a5423200246EAFdd9fa0f5d70eAde3067Dd6",
+            "name": "TE Connectivity (Ondo Tokenized)",
+            "symbol": "TELon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/telon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x5C50fFD365c852f5e72BFBc2c1aE621e2ACa5Ece",
+            "name": "TE Connectivity (Ondo Tokenized)",
+            "symbol": "TELon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/telon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x24e7504246DFdd7E866936e2816BFbEa73bd890a",
+            "name": "Hubbell (Ondo Tokenized)",
+            "symbol": "HUBBon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/hubbon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x1C42C07257F936a7c4f84B8D756c95817E23631A",
+            "name": "Hubbell (Ondo Tokenized)",
+            "symbol": "HUBBon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/hubbon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x7F24e4f5dc9ce7D00170C91Ce18326E01d702242",
+            "name": "Worthington Steel (Ondo Tokenized)",
+            "symbol": "WSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/wson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x50e66EDb7D0b79Ee988f098754A27aFaa643B4f5",
+            "name": "Worthington Steel (Ondo Tokenized)",
+            "symbol": "WSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/wson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xB50A8bd8883Dfe59eAF1a8b1130acD97CEd9AC84",
+            "name": "Atkore (Ondo Tokenized)",
+            "symbol": "ATKRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/atkron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xaFAA2087093b7B396ADAB8216506D9066c6A6F13",
+            "name": "Atkore (Ondo Tokenized)",
+            "symbol": "ATKRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/atkron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x4f5A3B3E184b1424816D9107448314ba0aAd63e1",
+            "name": "Cloudflare (Ondo Tokenized)",
+            "symbol": "NETon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/neton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xfEb0793EEa97585Eb3a541F3FD53450D225b2B87",
+            "name": "Cloudflare (Ondo Tokenized)",
+            "symbol": "NETon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/neton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xE2c149FA719d43912BfE584c71c9a6a018a5e916",
+            "name": "USA Rare Earth (Ondo Tokenized)",
+            "symbol": "USARon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/usaron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x2206E07410A8fE9Ef595e7184B2E9d160fdb7211",
+            "name": "USA Rare Earth (Ondo Tokenized)",
+            "symbol": "USARon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/usaron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xabC32C14CE8502Ff6B63Adc2907B9458c06A6856",
+            "name": "Himax Technologies (Ondo Tokenized)",
+            "symbol": "HIMXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/himxon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x6cF3b84f0Ba4d86d9f6987812A11Db2c447D9483",
+            "name": "Himax Technologies (Ondo Tokenized)",
+            "symbol": "HIMXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/himxon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xD1C3bF5DdE6ee17Ae2a472a8C4f0258e0B350cb4",
+            "name": "MaxLinear (Ondo Tokenized)",
+            "symbol": "MXLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/mxlon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x5Cb7671740877723c9aD55348a751D7B57052E07",
+            "name": "MaxLinear (Ondo Tokenized)",
+            "symbol": "MXLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/mxlon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xC29FF16a7B0a895E9fE05c32Ce3f26c44e8eca3D",
+            "name": "Onto Innovation (Ondo Tokenized)",
+            "symbol": "ONTOon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ontoon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x2F79d36184DfE7968C9d23f87cAe1aB72447c1e5",
+            "name": "Onto Innovation (Ondo Tokenized)",
+            "symbol": "ONTOon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ontoon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x67A47353D5449fC24088190c44247d4D4E296073",
+            "name": "Ouster (Ondo Tokenized)",
+            "symbol": "OUSTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ouston_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x30033A17ea24E90631532582a1917c64AFBF87Af",
+            "name": "Ouster (Ondo Tokenized)",
+            "symbol": "OUSTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ouston_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x1d1b9ae25722d0B27dB23171CFeE0C269B203695",
+            "name": "Teradyne (Ondo Tokenized)",
+            "symbol": "TERon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/teron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x6F040fC3061374304BddbfdAe9d688d7C868c785",
+            "name": "Teradyne (Ondo Tokenized)",
+            "symbol": "TERon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/teron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x01E7eaF05Be1d0c2D1834fC65080188376026d07",
+            "name": "Nokia (Ondo Tokenized)",
+            "symbol": "NOKon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/nokon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xE9518CB0010C717DB69001F1418EFF9e97330137",
+            "name": "Nokia (Ondo Tokenized)",
+            "symbol": "NOKon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/nokon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xa656C5Dd6B64b3AcB6E32aF8A876a48B5748f858",
+            "name": "Planet Labs (Ondo Tokenized)",
+            "symbol": "PLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/plon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xf9015E0b3AB4ddd216F522D6150dB826c9BE83f8",
+            "name": "Planet Labs (Ondo Tokenized)",
+            "symbol": "PLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/plon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xB2e9Ec5c62f78596cA4a21a21570b9a00c6D226c",
+            "name": "Enbridge (Ondo Tokenized)",
+            "symbol": "ENBon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/enbon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x5397cB3f1E419050D9d7160756dE0f4eD4f5f898",
+            "name": "Enbridge (Ondo Tokenized)",
+            "symbol": "ENBon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/enbon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x1DB23e5C0da6b960D0cf3D9939Cbf50A2514bfC2",
+            "name": "MYR Group (Ondo Tokenized)",
+            "symbol": "MYRGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/myrgon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x93b83111c54aa3993B2De5FCcD4c70B26c522D5d",
+            "name": "MYR Group (Ondo Tokenized)",
+            "symbol": "MYRGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/myrgon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x44Abf03ca01B8e7877bC3Dbc37b132F6f25E9450",
+            "name": "Entegris (Ondo Tokenized)",
+            "symbol": "ENTGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/entgon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xfB4a89A077B9020C7101b1Af760BEB708F37a416",
+            "name": "Entegris (Ondo Tokenized)",
+            "symbol": "ENTGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/entgon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xE67AbcA57E1504a26bd2eD209F2e0C09543Fd7Eb",
+            "name": "Hewlett Packard Enterprise (Ondo Tokenized)",
+            "symbol": "HPEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/hpeon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x492E678c1ea048C70eDc635047cdBB87FF5362a2",
+            "name": "Hewlett Packard Enterprise (Ondo Tokenized)",
+            "symbol": "HPEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/hpeon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x0e05BA0756C504B69AAA642f7379CD1AF7C63969",
+            "name": "RoboStrategy (Ondo Tokenized)",
+            "symbol": "BOTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/boton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xC43Ae29aFE58bf90dA6Fe3Edd570C2E735fb2850",
+            "name": "RoboStrategy (Ondo Tokenized)",
+            "symbol": "BOTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/boton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x55025c1e2acFE5A7092CF32f7A4F351a9FD21e1c",
+            "name": "Alpha and Omega Semiconductor (Ondo Tokenized)",
+            "symbol": "AOSLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aoslon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x55B8cc618C4209A97250Dff926d3d708814d36aa",
+            "name": "Alpha and Omega Semiconductor (Ondo Tokenized)",
+            "symbol": "AOSLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aoslon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x92e04b1fCC2b16347820241D226853Cf01C9eBAB",
+            "name": "Bloom Energy (Ondo Tokenized)",
+            "symbol": "BEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/beon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x17D03aE104a9D12E9E5794Efb109B817Dd7f3404",
+            "name": "Bloom Energy (Ondo Tokenized)",
+            "symbol": "BEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/beon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x0a600856eEDCe367eD49C3cd399775DC95d8BB5a",
+            "name": "NuScale Power (Ondo Tokenized)",
+            "symbol": "SMRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/smron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xf4b674D4E33c36F8db4b928A5eEC4E1F87b386e3",
+            "name": "NuScale Power (Ondo Tokenized)",
+            "symbol": "SMRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/smron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xF5852886Fff060dF3Af99a4246456fCa26445e8c",
+            "name": "STMicroelectronics (Ondo Tokenized)",
+            "symbol": "STMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/stmon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x8B46599e0E80a34F37e97DF58E741ca904cdfaBd",
+            "name": "STMicroelectronics (Ondo Tokenized)",
+            "symbol": "STMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/stmon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x05d2d23398756821dC3DE359ffCe8EBbD50af8c5",
+            "name": "EQT (Ondo Tokenized)",
+            "symbol": "EQTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/eqton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x9A1C88ac479906A7f03e76605b15B72DF10d8E51",
+            "name": "EQT (Ondo Tokenized)",
+            "symbol": "EQTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/eqton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xCAfD1c0EE8B392cb446e3E745A4ADEfF7A861995",
+            "name": "SAP (Ondo Tokenized)",
+            "symbol": "SAPon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/sapon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x111f6F2B9F1C5f3Ec841690e1deEc606086727dA",
+            "name": "SAP (Ondo Tokenized)",
+            "symbol": "SAPon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/sapon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xfB6d594CccfDEd3606e1500b92a26b8B43a35071",
+            "name": "Williams (Ondo Tokenized)",
+            "symbol": "WMBon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/wmbon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x7B7AbD762a400c9768CDeeEF3C01DaE39e0B8427",
+            "name": "Williams (Ondo Tokenized)",
+            "symbol": "WMBon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/wmbon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xb5dd7ff8E2e4019cA7a55f10C13282071a5775D4",
+            "name": "NANO Nuclear Energy (Ondo Tokenized)",
+            "symbol": "NNEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/nneon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x3c276Dd9f9Eab5510f9eAfD3a6Ea54879b27CA3D",
+            "name": "NANO Nuclear Energy (Ondo Tokenized)",
+            "symbol": "NNEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/nneon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xf6C9C6b33BD3df0d761702db7075f89e561A54D8",
+            "name": "Fluence Energy (Ondo Tokenized)",
+            "symbol": "FLNCon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/flncon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xF1a96d4B591E446445600789D60C73Dd636B357c",
+            "name": "Fluence Energy (Ondo Tokenized)",
+            "symbol": "FLNCon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/flncon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x61882Bb63aF8e6A39531175CdfDe1Fcd98346503",
+            "name": "Cerebras Systems (Ondo Tokenized)",
+            "symbol": "CBRSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/cbrson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x441a4D4Fc23f17F4cf23E3d60F12d2BD6F176728",
+            "name": "Cerebras Systems (Ondo Tokenized)",
+            "symbol": "CBRSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/cbrson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xeE9f43476C5b7292b114bA1b280A42A8746792d4",
+            "name": "Dell Technologies (Ondo Tokenized)",
+            "symbol": "DELLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/dellon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xf26518958935654878De15BE7bC79A26971583Ba",
+            "name": "Dell Technologies (Ondo Tokenized)",
+            "symbol": "DELLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/dellon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xEbe0D1B1d50bC68458Fcdc45C3c276d57CDC422B",
+            "name": "Tower Semiconductor (Ondo Tokenized)",
+            "symbol": "TSEMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/tsemon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x343324170C91c4D8Cf4D439B3E5a619F50621aE7",
+            "name": "Tower Semiconductor (Ondo Tokenized)",
+            "symbol": "TSEMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/tsemon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x1ffAc2Df9696868D06F9fe8d72fEE9e1452eeF76",
+            "name": "Ciena (Ondo Tokenized)",
+            "symbol": "CIENon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/cienon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x89a9F7114bE6b220fAe645ba0cbB720889867415",
+            "name": "Ciena (Ondo Tokenized)",
+            "symbol": "CIENon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/cienon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x93A96721a624822A6aB6461A7891a5C6b154102F",
+            "name": "Fabrinet (Ondo Tokenized)",
+            "symbol": "FNon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/fnon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xA1DaaB37dA2a29A1eC721922b55962eB8B481001",
+            "name": "Fabrinet (Ondo Tokenized)",
+            "symbol": "FNon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/fnon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x45583545BE579cc96409903597c5e17B3fd7ceFf",
+            "name": "Arqit Quantum (Ondo Tokenized)",
+            "symbol": "ARQQon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/arqqon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x1161989389A991532dCE453D04d6346C2581c907",
+            "name": "Arqit Quantum (Ondo Tokenized)",
+            "symbol": "ARQQon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/arqqon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xd6D09189B6fD611A75435e4a123e373A56Ab0e41",
+            "name": "Astera Labs (Ondo Tokenized)",
+            "symbol": "ALABon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/alabon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x573e11CC667A8E5BE0c7Af2410403371088D3d0D",
+            "name": "Astera Labs (Ondo Tokenized)",
+            "symbol": "ALABon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/alabon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xB348a4Bce7FaE890d2d37Ea104e59fb3881757c2",
+            "name": "Credo Technology Group Holding (Ondo Tokenized)",
+            "symbol": "CRDOon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/crdoon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xf157481bEBd0C0686780fd0F61806C900A6137e8",
+            "name": "Credo Technology Group Holding (Ondo Tokenized)",
+            "symbol": "CRDOon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/crdoon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x6e9C4BcEDDd057D66b65794A0093ad95c5fa0Cc4",
+            "name": "MACOM Technology Solutions Holdings (Ondo Tokenized)",
+            "symbol": "MTSIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/mtsion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x1dCd320C5d7b84CD407437c58d56CbbDd0D9d8f3",
+            "name": "MACOM Technology Solutions Holdings (Ondo Tokenized)",
+            "symbol": "MTSIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/mtsion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x5bC56F5A324BB572B934cED4448055e30ec11c0c",
+            "name": "Lightwave Logic (Ondo Tokenized)",
+            "symbol": "LWLGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/lwlgon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x8aC67002282EeA816aFA0160d22a8d27f05BA07B",
+            "name": "Lightwave Logic (Ondo Tokenized)",
+            "symbol": "LWLGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/lwlgon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x41fA6d32917E17cF29a5e93940471492D7c301C8",
+            "name": "Penguin Solutions (Ondo Tokenized)",
+            "symbol": "PENGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/pengon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x2144d620E3471441b12Bf256E01a09EAA5ea7F12",
+            "name": "Penguin Solutions (Ondo Tokenized)",
+            "symbol": "PENGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/pengon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xb71c4EBB4eDbAd867290206239C19DBb59eD55E1",
+            "name": "FuelCell Energy (Ondo Tokenized)",
+            "symbol": "FCELon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/fcelon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x47Bfe4921Bd74C66c6B0C35C517aBdFB5E3BAFb3",
+            "name": "FuelCell Energy (Ondo Tokenized)",
+            "symbol": "FCELon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/fcelon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x1c4c8a66884F1eeC60AA203C6cB51fD6CB76dbb9",
+            "name": "Vishay Precision Group (Ondo Tokenized)",
+            "symbol": "VPGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/vpgon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xAd8920aFa9d158F5eBAb77c9FfcAD650D72e473D",
+            "name": "Vishay Precision Group (Ondo Tokenized)",
+            "symbol": "VPGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/vpgon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x9A73A9CC7c5889C521423870e896904F71562504",
+            "name": "LightPath Technologies (Ondo Tokenized)",
+            "symbol": "LPTHon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/lpthon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x6AD19E0A57Cfea0bC521A12C6c82372852842933",
+            "name": "LightPath Technologies (Ondo Tokenized)",
+            "symbol": "LPTHon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/lpthon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x4ef7A9145e7B3C92E23A97FB41A9F4E9856288CB",
+            "name": "Rockwell Automation (Ondo Tokenized)",
+            "symbol": "ROKon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/rokon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x95F7423c51Eab71cBD00ca855B0B2B2153F14184",
+            "name": "Rockwell Automation (Ondo Tokenized)",
+            "symbol": "ROKon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/rokon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xc4Fa11Ed5141195cCBa19180628fa5091f53790b",
+            "name": "Mobileye Global (Ondo Tokenized)",
+            "symbol": "MBLYon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/mblyon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xCC977B493f52B4b6B6a0c3594530f2BaEe565E96",
+            "name": "Mobileye Global (Ondo Tokenized)",
+            "symbol": "MBLYon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/mblyon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xFc9D0eBBd17d3aAa336a50488795806c69EA4b32",
+            "name": "Aurora Innovation (Ondo Tokenized)",
+            "symbol": "AURon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/auron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x66a1409FE303d00209202933e3d31eE43AaAB39d",
+            "name": "Aurora Innovation (Ondo Tokenized)",
+            "symbol": "AURon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/auron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x1630281079eBaC2E873FB1F1cB41df3D0e451E23",
+            "name": "Celestica (Ondo Tokenized)",
+            "symbol": "CLSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/clson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x7b695132b165cb6703F0212bBB1e91A782526156",
+            "name": "Celestica (Ondo Tokenized)",
+            "symbol": "CLSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/clson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xD569Ff7f1560F71874Bc52D4728Fb2921e3DcE05",
+            "name": "Kopin (Ondo Tokenized)",
+            "symbol": "KOPNon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/kopnon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xED5615c5280E897241b9e4f019562A581cD49390",
+            "name": "Kopin (Ondo Tokenized)",
+            "symbol": "KOPNon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/kopnon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xD120f60FeC8189ed4a2346E10107B0F1F61354Cb",
+            "name": "Generac Holdings (Ondo Tokenized)",
+            "symbol": "GNRCon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/gnrcon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x237c9F794EDAaA0071cDF64a41c25EB76771754b",
+            "name": "Generac Holdings (Ondo Tokenized)",
+            "symbol": "GNRCon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/gnrcon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x26E78f7170d8Cc3bd3865d37CE4c554B65B1C9ba",
+            "name": "Trane Technologies (Ondo Tokenized)",
+            "symbol": "TTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/tton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x0Afa28A7Ac4E44b1F771515c200F4d67B1f5e8d0",
+            "name": "Trane Technologies (Ondo Tokenized)",
+            "symbol": "TTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/tton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x8B935EB2c98B597577359dEF9B18b4ae1523E6Cf",
+            "name": "Fundrise Innovation Fund (Ondo Tokenized)",
+            "symbol": "VCXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/vcxon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xC8206bB42EC019f7E7Ea060ED887E9F5bB53cBB0",
+            "name": "Fundrise Innovation Fund (Ondo Tokenized)",
+            "symbol": "VCXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/vcxon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xB326821B68313082F00A1A4d6Fa3f924D3E826Dc",
+            "name": "GlobalFoundries (Ondo Tokenized)",
+            "symbol": "GFSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/gfson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xAff6b836d3eBd29aEb0C8b840Add04EF79d79678",
+            "name": "GlobalFoundries (Ondo Tokenized)",
+            "symbol": "GFSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/gfson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xF14d47AeD45e16BF1f6E06904ac7f852FCe6cdf4",
+            "name": "Energy Fuels (Ondo Tokenized)",
+            "symbol": "UUUUon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/uuuuon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xD2C06fef2ca2375a9C7ceB4AbcA9DBc2aB6aF981",
+            "name": "Energy Fuels (Ondo Tokenized)",
+            "symbol": "UUUUon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/uuuuon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xB4d71137656150E97f3ed2C18d4a30bE138D8f2e",
+            "name": "Quanta Services (Ondo Tokenized)",
+            "symbol": "PWRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/pwron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x2418c2e1aE3B8D767594b3974D32610743f88155",
+            "name": "Quanta Services (Ondo Tokenized)",
+            "symbol": "PWRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/pwron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xddAf7945093ad7457228c185783FDf6aB25022B2",
+            "name": "Core Scientific (Ondo Tokenized)",
+            "symbol": "CORZon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/corzon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x25eD86472cf3012607DC6576c58e6432968255C2",
+            "name": "Core Scientific (Ondo Tokenized)",
+            "symbol": "CORZon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/corzon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xdf3F2315D124F7F8b714Ba031d6e69aA16a61FA2",
+            "name": "Hut 8 (Ondo Tokenized)",
+            "symbol": "HUTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/huton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x3A82f1C847cc55e52e597fD81c63a812C6722541",
+            "name": "Hut 8 (Ondo Tokenized)",
+            "symbol": "HUTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/huton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x6c51001149c7782820c107ADcE650692aB6c5378",
+            "name": "Vicor (Ondo Tokenized)",
+            "symbol": "VICRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/vicron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xa59469D91563CaeedDd2ffC731f41215E7b691ef",
+            "name": "Vicor (Ondo Tokenized)",
+            "symbol": "VICRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/vicron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xD9C1b5df94063177CF168680b695A417919aE1ae",
+            "name": "Amphenol (Ondo Tokenized)",
+            "symbol": "APHon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aphon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x70AfC3a600f843d2018dF16B0b316E4BC9c603E9",
+            "name": "Amphenol (Ondo Tokenized)",
+            "symbol": "APHon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aphon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x1b8085e78877dfBA98692Cb918809b35f6280015",
+            "name": "Powell Industries (Ondo Tokenized)",
+            "symbol": "POWLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/powlon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xD381aec27DAAcCC87F102FF4Ad6652F8b5F20bA0",
+            "name": "Powell Industries (Ondo Tokenized)",
+            "symbol": "POWLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/powlon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xa95837130Bcbc0AD99e188E22F674E4eC6925be2",
+            "name": "Cleveland-Cliffs (Ondo Tokenized)",
+            "symbol": "CLFon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/clfon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xaC38a6608868e2f487d7993EA7339C69e5AB077b",
+            "name": "Cleveland-Cliffs (Ondo Tokenized)",
+            "symbol": "CLFon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/clfon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xA9F9BE37b19F261AB067C5f7DEDA2c969Ec66944",
+            "name": "Cameco (Ondo Tokenized)",
+            "symbol": "CCJon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ccjon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xa75F08b9a91439DAac9cc7072857cC0a98Cf527A",
+            "name": "Cameco (Ondo Tokenized)",
+            "symbol": "CCJon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ccjon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x2D9fc6C5dD136658ab6190f356ae3186c4Daa7D5",
+            "name": "Navitas Semiconductor (Ondo Tokenized)",
+            "symbol": "NVTSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/nvtson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xB56B7C2F9988448790B0F78697F405aB5e8597E6",
+            "name": "Navitas Semiconductor (Ondo Tokenized)",
+            "symbol": "NVTSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/nvtson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xfcBa0eEBbb946FF933C91D2DDB2991845a400F39",
+            "name": "iShares Floating Rate Loan Active ETF (Ondo Tokenized)",
+            "symbol": "BRLNon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/brlnon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xD41829Dec8b51119176Ee0a6b73BC8B2718546A9",
+            "name": "iShares Floating Rate Loan Active ETF (Ondo Tokenized)",
+            "symbol": "BRLNon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/brlnon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x65513b741541025731124408DEb1A714699E3ee8",
+            "name": "iShares Investment Grade Systematic Bond ETF (Ondo Tokenized)",
+            "symbol": "IGEBon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/igebon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x9e609E96B688927aa49Dcd9758E2081f0c48ccAB",
+            "name": "iShares Investment Grade Systematic Bond ETF (Ondo Tokenized)",
+            "symbol": "IGEBon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/igebon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xD175B950B71f623BcD31c430C23e3e4a3487BDa3",
+            "name": "iShares Aaa - A Rated Corporate Bond ETF (Ondo Tokenized)",
+            "symbol": "QLTAon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/qltaon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xBC34D36B70E5A256F3D16F9cA9D3ca3838f6cC4F",
+            "name": "iShares Aaa - A Rated Corporate Bond ETF (Ondo Tokenized)",
+            "symbol": "QLTAon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/qltaon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xaeB2C4f3540a162045cC3Bd82d367AC38C2F4Da6",
+            "name": "iShares High Yield Active ETF (Ondo Tokenized)",
+            "symbol": "BRHYon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/brhyon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x6860a2f969A8133A23421ddce21397995139D7e8",
+            "name": "iShares High Yield Active ETF (Ondo Tokenized)",
+            "symbol": "BRHYon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/brhyon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x08D777b6a82c8dee715848702F72dAD4c2504687",
+            "name": "iShares Large Cap Core Active ETF (Ondo Tokenized)",
+            "symbol": "BLCRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/blcron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x398aE5B33505f121C359f22B300FbcFa81DB79AE",
+            "name": "iShares Large Cap Core Active ETF (Ondo Tokenized)",
+            "symbol": "BLCRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/blcron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xcafC59d86FAD601ea321c44439fE9D5B8F02ef0F",
+            "name": "iShares US Industry Rotation Active ETF (Ondo Tokenized)",
+            "symbol": "INROon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/inroon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x790cFb394B1f399a3543Ba1F835DdE114A387eeb",
+            "name": "iShares US Industry Rotation Active ETF (Ondo Tokenized)",
+            "symbol": "INROon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/inroon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xa32847395b007ee4a40407E3DD2f8F9bF56Ca6aB",
+            "name": "iShares US Equity Factor Rotation Active ETF (Ondo Tokenized)",
+            "symbol": "DYNFon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/dynfon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x96A1b43C8146E6D1f6e66B226A3c520CbE3d8a50",
+            "name": "iShares US Equity Factor Rotation Active ETF (Ondo Tokenized)",
+            "symbol": "DYNFon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/dynfon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x9463b0EE32c1b40B7fdA6459e815F0790159bC3A",
+            "name": "iShares A.I. Innovation and Tech Active ETF (Ondo Tokenized)",
+            "symbol": "BAIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/baion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x2659Dd96deF34ceD3679901E5500779BE297fE5a",
+            "name": "iShares A.I. Innovation and Tech Active ETF (Ondo Tokenized)",
+            "symbol": "BAIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/baion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x744f87836d961E08b9305c690d663577718a0d0A",
+            "name": "iShares International Country Rotation Active ETF (Ondo Tokenized)",
+            "symbol": "COROon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/coroon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x23def658ea0B4081161d9AB8fDfEef5345bcaFBD",
+            "name": "iShares International Country Rotation Active ETF (Ondo Tokenized)",
+            "symbol": "COROon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/coroon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x3d45D340a30f49F036142e5e4D8993b9ad4e3F9a",
+            "name": "iShares Total Return Active ETF (Ondo Tokenized)",
+            "symbol": "BRTRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/brtron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x463196CC72cBad2D1AC1896CDE0766bfBBd64443",
+            "name": "iShares Total Return Active ETF (Ondo Tokenized)",
+            "symbol": "BRTRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/brtron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x9ED446b5CC93803291BfDa5346a5b634a93A500C",
+            "name": "iShares Systematic Alternatives Active ETF (Ondo Tokenized)",
+            "symbol": "IALTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ialton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x879Fc0D8DFdb13b4aF3513d9838f82c4Df8F57E8",
+            "name": "iShares Systematic Alternatives Active ETF (Ondo Tokenized)",
+            "symbol": "IALTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ialton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x5673154DAe5Dab8ca6Bd3ee42c3245dbFedC6611",
+            "name": "Oceaneering International (Ondo Tokenized)",
+            "symbol": "OIIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/oiion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x4321366277d4a6E170F1f28148C93E8c47636c14",
+            "name": "Oceaneering International (Ondo Tokenized)",
+            "symbol": "OIIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/oiion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xd0E60D2EF0841E49700772D9889123b9886194c7",
+            "name": "Iridium Communications (Ondo Tokenized)",
+            "symbol": "IRDMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/irdmon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x3cE678692a60Fb5F31963b05CB158F0cE0Ff1736",
+            "name": "Iridium Communications (Ondo Tokenized)",
+            "symbol": "IRDMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/irdmon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x448550De96bCBEF1d8ccd755b5BC842f58485b46",
+            "name": "Leonardo DRS (Ondo Tokenized)",
+            "symbol": "DRSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/drson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x2A0A317660F497d4c4836d1ef5fAF5970e69437b",
+            "name": "Leonardo DRS (Ondo Tokenized)",
+            "symbol": "DRSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/drson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x10bd54f1F4DC19bE0c46B1Ea7E5f38FD2eaFeE26",
+            "name": "Huntington Ingalls Industries (Ondo Tokenized)",
+            "symbol": "HIIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/hiion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x4Dc8dCeE22a56fEECa930dfF45581aa9A14D5E05",
+            "name": "Huntington Ingalls Industries (Ondo Tokenized)",
+            "symbol": "HIIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/hiion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xD68fa0978C257aace5BEc5246b201B56E838D45d",
+            "name": "General Dynamics (Ondo Tokenized)",
+            "symbol": "GDon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/gdon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x5d1a9d8aa362a6424b65Fcb601e52FefcE5b4EFA",
+            "name": "General Dynamics (Ondo Tokenized)",
+            "symbol": "GDon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/gdon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x241Aa03de25Bd3A6B6254258BEF7F287AF94b93C",
+            "name": "Vanguard Energy ETF (Ondo Tokenized)",
+            "symbol": "VDEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/vdeon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x9e23662f540C6bc117AdF91230730D9B2FDF5643",
+            "name": "Vanguard Energy ETF (Ondo Tokenized)",
+            "symbol": "VDEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/vdeon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xa65db7879774BD6758ABaF583A91177AfD96D5A3",
+            "name": "Sprott Uranium Miners ETF (Ondo Tokenized)",
+            "symbol": "URNMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/urnmon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xCa626a74420aAaf285987Da23d829f9159Ab867c",
+            "name": "Sprott Uranium Miners ETF (Ondo Tokenized)",
+            "symbol": "URNMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/urnmon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x22a684E0A3cc9B74596719F722cf4e597AAFA3bA",
+            "name": "US Copper Index Fund (Ondo Tokenized)",
+            "symbol": "CPERon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/cperon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x0888EDfeC4C0A66FCE074796CF4F6509c00f6c49",
+            "name": "US Copper Index Fund (Ondo Tokenized)",
+            "symbol": "CPERon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/cperon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xaa26e62e51bc5da24ED2B6Fc6491e137d68824B9",
+            "name": "First Majestic Silver (Ondo Tokenized)",
+            "symbol": "AGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/agon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xa2a97e3d6140e8ccD058f3b84230F3E1a349b1a3",
+            "name": "First Majestic Silver (Ondo Tokenized)",
+            "symbol": "AGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/agon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xCEA4290d6578f0253308304F7184eA2E8F5EB0E4",
+            "name": "SLB (Ondo Tokenized)",
+            "symbol": "SLBon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/slbon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xfaDdE620010736a5074a4269894Cb52B0a9a91DE",
+            "name": "SLB (Ondo Tokenized)",
+            "symbol": "SLBon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/slbon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x596b790CceE1032F6658Ac2c78a119cCE69727FC",
+            "name": "Halliburton (Ondo Tokenized)",
+            "symbol": "HALon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/halon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x7A18bB5FD6Ba6343180AfDCf6Dc406eF17F7fC04",
+            "name": "Halliburton (Ondo Tokenized)",
+            "symbol": "HALon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/halon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x4c26BeBd3EC5B0329f24dfeD0de10a7AD205D8c3",
+            "name": "Defiance Quantum ETF (Ondo Tokenized)",
+            "symbol": "QTUMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/qtumon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x467C7cF9AF95765C1Bd6542FfD516BF9603A19b9",
+            "name": "Defiance Quantum ETF (Ondo Tokenized)",
+            "symbol": "QTUMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/qtumon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xC15F11599828b0afB0C071994679EF9E685F9E2E",
+            "name": "Skyworks Solutions (Ondo Tokenized)",
+            "symbol": "SWKSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/swkson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x7Bd821eAad82cb92C1eA64DaC1f3bB2E787E959A",
+            "name": "Skyworks Solutions (Ondo Tokenized)",
+            "symbol": "SWKSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/swkson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x9784508a0758cBb43eCb9b62F4CF4b1b3a36480c",
+            "name": "United Microelectronics (Ondo Tokenized)",
+            "symbol": "UMCon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/umcon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x318ddd4d03d84A40cf44772385A0CFB3D4394049",
+            "name": "United Microelectronics (Ondo Tokenized)",
+            "symbol": "UMCon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/umcon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xD9584f80CCE13afC96BfD0188fd5C81E08f18C85",
+            "name": "Jabil (Ondo Tokenized)",
+            "symbol": "JBLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/jblon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x8D941EbB4921f8d43CFA65233B14A547f96559fc",
+            "name": "Jabil (Ondo Tokenized)",
+            "symbol": "JBLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/jblon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x4493E670F5a077D46Eb3389fFA9Af19999Ea54eD",
+            "name": "Flex (Ondo Tokenized)",
+            "symbol": "FLEXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/flexon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x102138be022f8D142bcB817F7264921d65209608",
+            "name": "Flex (Ondo Tokenized)",
+            "symbol": "FLEXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/flexon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x4032d3076974b89238adfe61085EC57fC4522646",
+            "name": "Invesco PHLX Semiconductor ETF (Ondo Tokenized)",
+            "symbol": "SOXQon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/soxqon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x15688f10470dFdDCb4E2d60CD2ACfd3eC418317a",
+            "name": "Invesco PHLX Semiconductor ETF (Ondo Tokenized)",
+            "symbol": "SOXQon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/soxqon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xd318bBBE6B6E83F74e7aCAEb5e94C08ddbDb44c0",
+            "name": "Direxion Daily Semi Bull 3X ETF (Ondo Tokenized)",
+            "symbol": "SOXLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/soxlon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xb943c8a0d77b656Daf5244Da060D647Fd9152289",
+            "name": "Direxion Daily Semi Bull 3X ETF (Ondo Tokenized)",
+            "symbol": "SOXLon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/soxlon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x01eb2eE6Ec05C304666210133B762088FF9965aC",
+            "name": "Direxion Daily Semi Bear 3X ETF (Ondo Tokenized)",
+            "symbol": "SOXSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/soxson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x335DD4112704f108b5Ddd8F8a44Bd9ed68522a80",
+            "name": "Direxion Daily Semi Bear 3X ETF (Ondo Tokenized)",
+            "symbol": "SOXSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/soxson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x77ADB9F3ff7aAcBA0eEcE50d1bBf51adA182d174",
+            "name": "Ultra Clean Holdings (Ondo Tokenized)",
+            "symbol": "UCTTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/uctton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xB78ccbcd9DCE42D4fa5fdC835CB6a1aa1095a3b5",
+            "name": "Ultra Clean Holdings (Ondo Tokenized)",
+            "symbol": "UCTTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/uctton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x6785cE8060655b1F4991C3893dc41814154A1808",
+            "name": "Axcelis Technologies (Ondo Tokenized)",
+            "symbol": "ACLSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aclson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xF2e14fCE9259C8A7903c4be5326058aE2D004FC7",
+            "name": "Axcelis Technologies (Ondo Tokenized)",
+            "symbol": "ACLSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aclson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x948B03e4A1F1330d86Ea3adE02482639B5cCe720",
+            "name": "Cohu (Ondo Tokenized)",
+            "symbol": "COHUon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/cohuon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x58cE0De0CED164f2Aeab5FCf81D67f3c61CB562C",
+            "name": "Cohu (Ondo Tokenized)",
+            "symbol": "COHUon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/cohuon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x1E328BBCd67e1bbEE198bb3F90e764812e6E0AC9",
+            "name": "Keysight Technologies (Ondo Tokenized)",
+            "symbol": "KEYSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/keyson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x3de956D959726C448649354C6fBCa92B82dC5Ed7",
+            "name": "Keysight Technologies (Ondo Tokenized)",
+            "symbol": "KEYSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/keyson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xa9E5c59f34397fe6Baa9E4dA139bA4E63Bd84324",
+            "name": "iShares Expanded Tech-Software ETF (Ondo Tokenized)",
+            "symbol": "IGVon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/igvon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xA046C2F0A1Ac0a0E8829eFc12163ae892CEAfAc2",
+            "name": "iShares Expanded Tech-Software ETF (Ondo Tokenized)",
+            "symbol": "IGVon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/igvon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xc5a72B01Cc9e2721DC6dE1A35Ab8d92A6AA273e6",
+            "name": "VeriSign (Ondo Tokenized)",
+            "symbol": "VRSNon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/vrsnon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x37fF203Ac221313B620d047eddD7bD6F68d656a6",
+            "name": "VeriSign (Ondo Tokenized)",
+            "symbol": "VRSNon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/vrsnon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x6987F17A188c3B64F4892f0E31C2ccd88F54FCFd",
+            "name": "Vishay Intertechnology (Ondo Tokenized)",
+            "symbol": "VSHon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/vshon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x821aEf7d0F4347bB9EA6f293a98b19d823EEF0C5",
+            "name": "Vishay Intertechnology (Ondo Tokenized)",
+            "symbol": "VSHon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/vshon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x84601fdB21e3e892104e1Fe4a8269E7acA7C0E1A",
+            "name": "Methode Electronics (Ondo Tokenized)",
+            "symbol": "MEIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/meion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x89C37104aFcee9a72187E05D960a1e09763a126e",
+            "name": "Methode Electronics (Ondo Tokenized)",
+            "symbol": "MEIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/meion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xae1c6E353cdc9Dc3CC01124FFB62a0d0Ce64a401",
+            "name": "Rambus (Ondo Tokenized)",
+            "symbol": "RMBSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/rmbson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x49ccB157c77AFE5F264C35f0e9178a98D77815Ab",
+            "name": "Rambus (Ondo Tokenized)",
+            "symbol": "RMBSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/rmbson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x0D8EF471a11036Bc6dDa1536069457f7e97daB66",
+            "name": "Arteris (Ondo Tokenized)",
+            "symbol": "AIPon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aipon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xaE922B6cc2371B6Dce592A82Fac15ef890a7D467",
+            "name": "Arteris (Ondo Tokenized)",
+            "symbol": "AIPon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aipon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x04c8381e17b6A9245aBBF2e62c544eaEE4030D1b",
+            "name": "Extreme Networks (Ondo Tokenized)",
+            "symbol": "EXTRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/extron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x1EadA1306DF72A5607827416c1A1307d7056dFFf",
+            "name": "Extreme Networks (Ondo Tokenized)",
+            "symbol": "EXTRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/extron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xceb37aD46957047E22f726A7B25B134fC53AD753",
+            "name": "WhiteFiber (Ondo Tokenized)",
+            "symbol": "WYFIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/wyfion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xCe128eDcF46B281b7df8880867B74E11B055E8E7",
+            "name": "WhiteFiber (Ondo Tokenized)",
+            "symbol": "WYFIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/wyfion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xC76E008965b2f0E37896F52A2FEEe66EF2926ae8",
+            "name": "Digi Power X (Ondo Tokenized)",
+            "symbol": "DGXXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/dgxxon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x09f5a6ee1b46787dd252827E40502c4980a0285d",
+            "name": "Digi Power X (Ondo Tokenized)",
+            "symbol": "DGXXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/dgxxon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x0683154c33B7563ed39951B4d7C0470EA28D93e9",
+            "name": "Bitdeer Technologies (Ondo Tokenized)",
+            "symbol": "BTDRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/btdron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x3A562836AFB1026F5D7A6B6dA1125D27fdfeE372",
+            "name": "Bitdeer Technologies (Ondo Tokenized)",
+            "symbol": "BTDRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/btdron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x96c662b152BEC886fAcab388bd98470FD3Aa9737",
+            "name": "Keel Infrastructure (Ondo Tokenized)",
+            "symbol": "KEELon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/keelon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x5e3cA19c533C8C0381eac5319624596557C279ED",
+            "name": "Keel Infrastructure (Ondo Tokenized)",
+            "symbol": "KEELon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/keelon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x823cf9cCa5b8EAe0AE08fF3C6CD5102D2859DB4D",
+            "name": "HIVE Digital Technologies (Ondo Tokenized)",
+            "symbol": "HIVEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/hiveon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x3F19A16A401a6AF05150479Ccb76EF2Fb57B0dF3",
+            "name": "HIVE Digital Technologies (Ondo Tokenized)",
+            "symbol": "HIVEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/hiveon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xDEbb8E6F581655759e3D64f769247a007AF0aE36",
+            "name": "TTM Technologies (Ondo Tokenized)",
+            "symbol": "TTMIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ttmion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xF400b05AD5A791c65Acc3f905E5aDe5F1B653c8c",
+            "name": "TTM Technologies (Ondo Tokenized)",
+            "symbol": "TTMIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ttmion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xBa6FF85f4595a3E71F3a965E6B528bBcf51A2c79",
+            "name": "Primoris Services (Ondo Tokenized)",
+            "symbol": "PRIMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/primon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xD60b0276640a693ece55660afAC0383ca6433882",
+            "name": "Primoris Services (Ondo Tokenized)",
+            "symbol": "PRIMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/primon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xD62C0Bf1e1dD6F4FEe1b3D042A9E479Ad1Fb1BCb",
+            "name": "Lincoln Electric (Ondo Tokenized)",
+            "symbol": "LECOon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/lecoon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x43807bf4ce06F4fbb4FA8DEac37BF274AEa324Da",
+            "name": "Lincoln Electric (Ondo Tokenized)",
+            "symbol": "LECOon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/lecoon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x113faE6e1103A4C09250C8697a6a4BE6Ca987d06",
+            "name": "AMETEK (Ondo Tokenized)",
+            "symbol": "AMEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ameon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x7a5bD36047A9D15C90FA79b0654De8dd9d6eBbB1",
+            "name": "AMETEK (Ondo Tokenized)",
+            "symbol": "AMEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ameon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x410e7D6B6303E531753D4fbe3e50e35EfBcFf53c",
+            "name": "Forgent Power Solutions (Ondo Tokenized)",
+            "symbol": "FPSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/fpson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xd8dAFFd168651470cd5397A5D670DD5F8E4b02f5",
+            "name": "Forgent Power Solutions (Ondo Tokenized)",
+            "symbol": "FPSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/fpson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xF87efCA06f6Af53Cb096847bA092ccd04395A192",
+            "name": "WESCO International (Ondo Tokenized)",
+            "symbol": "WCCon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/wccon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x82436bAE31AE373258bA567f32087eeFc32189F2",
+            "name": "WESCO International (Ondo Tokenized)",
+            "symbol": "WCCon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/wccon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xEcA55ac71f83931B7e074228AEBc9104F13d8c02",
+            "name": "Breakwave Tanker Shipping ETF (Ondo Tokenized)",
+            "symbol": "BWETon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/bweton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x472F46C5D7409C82234701EFf7D4DDA4c28B5a93",
+            "name": "Breakwave Tanker Shipping ETF (Ondo Tokenized)",
+            "symbol": "BWETon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/bweton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xf25a149151033FcfAf069C1d007C3c2d2429bE8e",
+            "name": "Scorpio Tankers (Ondo Tokenized)",
+            "symbol": "STNGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/stngon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x4b1c9087a6fe265A36FBf2C591B0986fE1115F50",
+            "name": "Scorpio Tankers (Ondo Tokenized)",
+            "symbol": "STNGon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/stngon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x90c06Bccb5bd20c5a84cBD59A43Aa22cA96E588D",
+            "name": "Teekay Tankers (Ondo Tokenized)",
+            "symbol": "TNKon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/tnkon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x2BBF5ab85f9ceb595dD785Db15CC9f2931c6EA64",
+            "name": "Teekay Tankers (Ondo Tokenized)",
+            "symbol": "TNKon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/tnkon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x3f696db88acA815c150fEb9baAa9870F85b77494",
+            "name": "International Seaways (Ondo Tokenized)",
+            "symbol": "INSWon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/inswon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xE3316F5372559768E14Bc7FfE983891A742987E7",
+            "name": "International Seaways (Ondo Tokenized)",
+            "symbol": "INSWon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/inswon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xdb2e166F0c76b05BC07700CbF74cC36Ae2603624",
+            "name": "Tsakos Energy Navigation (Ondo Tokenized)",
+            "symbol": "TENon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/tenon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x686F8264625fe4E51F520Db856003A4dD52A49fF",
+            "name": "Tsakos Energy Navigation (Ondo Tokenized)",
+            "symbol": "TENon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/tenon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x64b84731cEC441370C90c1b06d66A17EAdfAcd0F",
+            "name": "Nordic American Tankers (Ondo Tokenized)",
+            "symbol": "NATon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/naton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x33F3df3cEA2A8c4828e88f30Be932850cf749739",
+            "name": "Nordic American Tankers (Ondo Tokenized)",
+            "symbol": "NATon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/naton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xD081B43E3C334B1a101981efC1D98F1E82df076E",
+            "name": "Okeanis Eco Tankers (Ondo Tokenized)",
+            "symbol": "ECOon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ecoon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x660ab35bE0f102A1d4d4B60A96Ac3abfd345e038",
+            "name": "Okeanis Eco Tankers (Ondo Tokenized)",
+            "symbol": "ECOon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ecoon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xEad51EE313a7187fc1a155C381270c764DA42770",
+            "name": "Westlake (Ondo Tokenized)",
+            "symbol": "WLKon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/wlkon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xb3D1a5F9bF92F18da643F2Ada2f2CdfDAE67E9d1",
+            "name": "Westlake (Ondo Tokenized)",
+            "symbol": "WLKon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/wlkon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x167f8D6B357FA9fff9B1286E519Bd32d4504757E",
+            "name": "Nucor (Ondo Tokenized)",
+            "symbol": "NUEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/nueon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x2155f5344BA7763f80420dE617Af41E56De0552b",
+            "name": "Nucor (Ondo Tokenized)",
+            "symbol": "NUEon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/nueon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xf9D5aF26E1B96625dBC86609463A06602bE42966",
+            "name": "Steel Dynamics (Ondo Tokenized)",
+            "symbol": "STLDon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/stldon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x90EAa91Af0B4559F1F270258Bb5cDDFafbb62da9",
+            "name": "Steel Dynamics (Ondo Tokenized)",
+            "symbol": "STLDon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/stldon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xa0Db1eCa4AaEBCa03A3c04ed221b036Dd3CcB025",
+            "name": "Lattice Semiconductor (Ondo Tokenized)",
+            "symbol": "LSCCon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/lsccon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x80F03ABCb2BD85237740dD69f87d2F5De3909012",
+            "name": "Lattice Semiconductor (Ondo Tokenized)",
+            "symbol": "LSCCon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/lsccon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xC4881Ce8269744B9255b926B76728eAdcB240A3B",
+            "name": "CEVA (Ondo Tokenized)",
+            "symbol": "CEVAon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/cevaon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x8B68b3D3173c406D2C5F4f2107D54E6562A23120",
+            "name": "CEVA (Ondo Tokenized)",
+            "symbol": "CEVAon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/cevaon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x26719965000A3DCAcc1451F836FbB9c883CCDe85",
+            "name": "Emerson Electric (Ondo Tokenized)",
+            "symbol": "EMRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/emron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x60B273bDf00a9A52238Ca706257f61efc55bDeE0",
+            "name": "Emerson Electric (Ondo Tokenized)",
+            "symbol": "EMRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/emron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x41d022C6008FbF431c5E5E88246A948B9E941EA3",
+            "name": "Symbotic (Ondo Tokenized)",
+            "symbol": "SYMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/symon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xc79Fc7aF952c8B41c6b7b7657dd24F44f7C10F2A",
+            "name": "Symbotic (Ondo Tokenized)",
+            "symbol": "SYMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/symon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x85bD7B075A9e0f6D7099dd750CEcd65CE57d4F44",
+            "name": "TaskUs (Ondo Tokenized)",
+            "symbol": "TASKon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/taskon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xDB69bEcc323fEc440cA8eb0C3564802E77cE2827",
+            "name": "TaskUs (Ondo Tokenized)",
+            "symbol": "TASKon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/taskon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x1C99a152e00a5dc40f8c3e893C1d04b0F6a48B0f",
+            "name": "Innodata (Ondo Tokenized)",
+            "symbol": "INODon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/inodon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x517A25e696421C88218B43cbb7EA0f873B6973A6",
+            "name": "Innodata (Ondo Tokenized)",
+            "symbol": "INODon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/inodon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xdC7E54dd476812F7cf1d77066f523aFE50eDAb1b",
+            "name": "Hesai Group (Ondo Tokenized)",
+            "symbol": "HSAIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/hsaion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x847ef23A3F99aF79A185ce033e1664165b846eEa",
+            "name": "Hesai Group (Ondo Tokenized)",
+            "symbol": "HSAIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/hsaion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x084A613FEd04B5d26672E38dc9c3aa13f3C1AE58",
+            "name": "United States Antimony (Ondo Tokenized)",
+            "symbol": "UAMYon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/uamyon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xf8919fe7D586b11D0A900E987c4A41bC6c3195F5",
+            "name": "United States Antimony (Ondo Tokenized)",
+            "symbol": "UAMYon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/uamyon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x4cDd1099146f28a9b428CD85F36B562B6d05c8c8",
+            "name": "REalloys (Ondo Tokenized)",
+            "symbol": "ALOYon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aloyon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x941e3a7A6fC97B094C63a0348367cf90D93Ff090",
+            "name": "REalloys (Ondo Tokenized)",
+            "symbol": "ALOYon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aloyon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x8379c5595b8148A9968bEE6D8110B2b4a627a9Dd",
+            "name": "ACM Research (Ondo Tokenized)",
+            "symbol": "ACMRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/acmron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xC5EFD0c3a8fF6D9816DA7B56625aB4C398Eb9e08",
+            "name": "ACM Research (Ondo Tokenized)",
+            "symbol": "ACMRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/acmron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x80d04221eC124850C4B9ba8f625b9a12AD609200",
+            "name": "Nova (Ondo Tokenized)",
+            "symbol": "NVMIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/nvmion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x8a5f83A4b3AD2B9604F53c4dDf8DcE1329f9d433",
+            "name": "Nova (Ondo Tokenized)",
+            "symbol": "NVMIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/nvmion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xF02b8309df07641dDcFd1DABCeFFDde3d30915De",
+            "name": "Amkor Technology (Ondo Tokenized)",
+            "symbol": "AMKRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/amkron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xb84e150A1d18380cFeEeBCdE8756368dD489A1A3",
+            "name": "Amkor Technology (Ondo Tokenized)",
+            "symbol": "AMKRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/amkron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x6E9C573e5b8A59CEC47D8E317C148E4b0595FB39",
+            "name": "AAON (Ondo Tokenized)",
+            "symbol": "AAONon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aaonon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x0B61036b5182A29A228d8eD9e647a16f62baD1bC",
+            "name": "AAON (Ondo Tokenized)",
+            "symbol": "AAONon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aaonon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xa4daA3f53405BEa3B1E5701b6Db2DDC0efc4C8b2",
+            "name": "Harmonic (Ondo Tokenized)",
+            "symbol": "HLITon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/hliton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xfF6f45B2D761CDE4dAb7F5d7A1A5f691F52F3bC3",
+            "name": "Harmonic (Ondo Tokenized)",
+            "symbol": "HLITon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/hliton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x94912D9f8ef1108CA605A6F5331a0dA0294Adfe0",
+            "name": "ASE Technology Holding (Ondo Tokenized)",
+            "symbol": "ASXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/asxon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xB695fAe94eBCA7b873aB139856CeebC68C5098CE",
+            "name": "ASE Technology Holding (Ondo Tokenized)",
+            "symbol": "ASXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/asxon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xdB5a8f5B4C17f2Ee2e7192A150687E48eB3C415d",
+            "name": "Roundhill Memory ETF (Ondo Tokenized)",
+            "symbol": "DRAMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/dramon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x087b5761b161429013d41eA54cd2fb6022A21564",
+            "name": "Roundhill Memory ETF (Ondo Tokenized)",
+            "symbol": "DRAMon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/dramon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xfb1b703B26957C344aAb03BBE11EC9C23E9eDdf5",
+            "name": "Global X MSCI Argentina ETF (Ondo Tokenized)",
+            "symbol": "ARGTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/argton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x2b08f1c28Cb1EdE3b11D397929F00215fA97ecFA",
+            "name": "Global X MSCI Argentina ETF (Ondo Tokenized)",
+            "symbol": "ARGTon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/argton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x211d1d372E6A782e9786b045004382834bDB224e",
+            "name": "Hyperliquid Strategies (Ondo Tokenized)",
+            "symbol": "PURRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/purron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x89CC700F308a4C59889fBF3286216554C53B0601",
+            "name": "Hyperliquid Strategies (Ondo Tokenized)",
+            "symbol": "PURRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/purron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xFb4Aa24c9c4E65f82d57d268dA8a65a0dE0DC43B",
+            "name": "Global X Defense Tech ETF (Ondo Tokenized)",
+            "symbol": "SHLDon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/shldon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xe5ca1585c6053EE891027fD0A2548cB3B27D7f01",
+            "name": "Global X Defense Tech ETF (Ondo Tokenized)",
+            "symbol": "SHLDon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/shldon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x7AbeC847A3f9820397C82E1DAd231721Bf5a6732",
+            "name": "Global X Robotics & Artificial Intelligence ETF (Ondo Tokenized)",
+            "symbol": "BOTZon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/botzon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xb42f5597EAdd424de67b46Fe5d1EC4b61367A4e5",
+            "name": "Global X Robotics & Artificial Intelligence ETF (Ondo Tokenized)",
+            "symbol": "BOTZon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/botzon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x3EB4293B73080214012DeF05244eC291094C6C14",
+            "name": "Global X Lithium & Battery Tech ETF (Ondo Tokenized)",
+            "symbol": "LITon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/liton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xfd7778D5d4e804b5B512471Df36d60C465199A52",
+            "name": "Global X Lithium & Battery Tech ETF (Ondo Tokenized)",
+            "symbol": "LITon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/liton_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x4D9216151Dad1AF871A6EeC623e2F04E7a2717b3",
+            "name": "Global X Data Center & Digital Infrastructure ETF (Ondo Tokenized)",
+            "symbol": "DTCRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/dtcron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xEc4C1944682B8c7ba6c825e9A8B2B32Cb5EcacE5",
+            "name": "Global X Data Center & Digital Infrastructure ETF (Ondo Tokenized)",
+            "symbol": "DTCRon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/dtcron_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xf8fd3698cA42c07f502150C19DD1D96B687f53Cd",
+            "name": "Global X Space Tech ETF (Ondo Tokenized)",
+            "symbol": "ORBXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/orbxon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x2bC97B1c5F83F080798ee9E38Da5FBF621454FCf",
+            "name": "Global X Space Tech ETF (Ondo Tokenized)",
+            "symbol": "ORBXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/orbxon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x34B33399a629fEd8EDC216EEb76C8309024C8987",
+            "name": "iShares Euro High Yield Corporate Bond USD Hedged ETF (Ondo Tokenized)",
+            "symbol": "EUHYon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/euhyon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x93eb8376ec73dD07F46ba7ae1EE9b0bbD937Ad93",
+            "name": "iShares Euro High Yield Corporate Bond USD Hedged ETF (Ondo Tokenized)",
+            "symbol": "EUHYon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/euhyon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xd9E7C53205048F83859815852616cd65D87AA83E",
+            "name": "iShares J.P. Morgan EM Local Currency Bond ETF (Ondo Tokenized)",
+            "symbol": "LEMBon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/lembon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x653156b9a46E21906Dddc82414871bBDB0261319",
+            "name": "iShares J.P. Morgan EM Local Currency Bond ETF (Ondo Tokenized)",
+            "symbol": "LEMBon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/lembon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x927dB66Cd5B55E9Df22d1D2207fBF059915240bB",
+            "name": "iShares Defense Industrials Active ETF (Ondo Tokenized)",
+            "symbol": "IDEFon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/idefon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x5Fb339393773414039295ea97A92614fed85D556",
+            "name": "iShares Defense Industrials Active ETF (Ondo Tokenized)",
+            "symbol": "IDEFon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/idefon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xfBd7880EBC5c2b1B871a8CE188C05311015139F4",
+            "name": "iShares Global Government Bond USD Hedged Active ETF (Ondo Tokenized)",
+            "symbol": "GGOVon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ggovon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x8Dd51E233E2344498F876c231a3Bd962E9750a6C",
+            "name": "iShares Global Government Bond USD Hedged Active ETF (Ondo Tokenized)",
+            "symbol": "GGOVon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ggovon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xA7776B3d801A6626807E0Db357C7EE2a8962903b",
+            "name": "Global X NASDAQ 100 Covered Call ETF (Ondo Tokenized)",
+            "symbol": "QYLDon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/qyldon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x64E023411215C3b75b9F339B7B77F179cd04C527",
+            "name": "Global X NASDAQ 100 Covered Call ETF (Ondo Tokenized)",
+            "symbol": "QYLDon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/qyldon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x603E505799511155A9216D37cF9e051171240b4c",
+            "name": "Global X Silver Miners ETF (Ondo Tokenized)",
+            "symbol": "SILon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/silon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x6A4c1B7aA18638fac4C8e0d1961405E27C25baf1",
+            "name": "Global X Silver Miners ETF (Ondo Tokenized)",
+            "symbol": "SILon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/silon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x2A5ae1BdE731cb8732fD762073DD0bBE151360B9",
+            "name": "Global X Artificial Intelligence & Technology ETF (Ondo Tokenized)",
+            "symbol": "AIQon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aiqon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x333932F15E6E14f4a630163D3224548a721DdfA4",
+            "name": "Global X Artificial Intelligence & Technology ETF (Ondo Tokenized)",
+            "symbol": "AIQon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/aiqon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xDd00b1046692aA2780ef04849829609Fc4F90fD7",
+            "name": "Global X Blockchain ETF (Ondo Tokenized)",
+            "symbol": "BKCHon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/bkchon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x2291E5361F4ef7bB0d6703377bF497bFe4325152",
+            "name": "Global X Blockchain ETF (Ondo Tokenized)",
+            "symbol": "BKCHon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/bkchon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x1252c5fa0a4031F6843D5Cf8d4986Ba99a8A9b42",
+            "name": "iShares MSCI EAFE Value ETF (Ondo Tokenized)",
+            "symbol": "EFVon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/efvon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x40375E3Dd70232eaF264706e5662b90A079e3D31",
+            "name": "iShares MSCI EAFE Value ETF (Ondo Tokenized)",
+            "symbol": "EFVon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/efvon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xc0e1F30E45da2dced2c35D89947C20bffBa6f529",
+            "name": "iShares S&P Small-Cap 600 Value ETF (Ondo Tokenized)",
+            "symbol": "IJSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ijson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x9609f804FD90440Dd3F4AfA1E0a4D57DFd580Ce8",
+            "name": "iShares S&P Small-Cap 600 Value ETF (Ondo Tokenized)",
+            "symbol": "IJSon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ijson_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x1577D4ae114B6F217453b754AeaC164db44832DA",
+            "name": "iShares US Technology ETF (Ondo Tokenized)",
+            "symbol": "IYWon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/iywon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xbEeEF4361F6603eDAceF5205b343C6bb6473A099",
+            "name": "iShares US Technology ETF (Ondo Tokenized)",
+            "symbol": "IYWon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/iywon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x034c9ffeC64597E0a0622ca5B9eAF00839052e0a",
+            "name": "Global X S&P 500 Covered Call ETF (Ondo Tokenized)",
+            "symbol": "XYLDon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/xyldon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x1FE12ABDF560C753aCbC63533519d74801E04958",
+            "name": "Global X S&P 500 Covered Call ETF (Ondo Tokenized)",
+            "symbol": "XYLDon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/xyldon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x2710E30d84B376c34a3B3036aa196b26a83A321b",
+            "name": "SPDR Bloomberg 1-3 Month T-Bill ETF (Ondo Tokenized)",
+            "symbol": "BILon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/bilon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x03f09E2EF6e64D804a5579E21E7b519db174cf54",
+            "name": "SPDR Bloomberg 1-3 Month T-Bill ETF (Ondo Tokenized)",
+            "symbol": "BILon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/bilon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xe905C437A30AE6d8c0576E0D9F6360B93B94976D",
+            "name": "iShares 3-7 Year Treasury Bond ETF (Ondo Tokenized)",
+            "symbol": "IEIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ieion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x4E07B55E62f443859706E03aeA0b3fe3a1bfEA8B",
+            "name": "iShares 3-7 Year Treasury Bond ETF (Ondo Tokenized)",
+            "symbol": "IEIon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/ieion_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0x5f24DD5DDb74bFe2BFE592aD91DBA09347031afd",
+            "name": "AB Ultra Short Income ETF (Ondo Tokenized)",
+            "symbol": "YEARon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/yearon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0x4277d20430e901092E259bA9CF7164C37077aAF1",
+            "name": "AB Ultra Short Income ETF (Ondo Tokenized)",
+            "symbol": "YEARon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/yearon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 1,
+            "address": "0xc9eef266834730340A55B6CC24621B31BAF55581",
+            "name": "SpaceX (Ondo Tokenized)",
+            "symbol": "SPCXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/spcxon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
+        },
+        {
+            "chainId": 56,
+            "address": "0xd0a58BC9D88D3FF48C0294Cb7e45937d0E41A928",
+            "name": "SpaceX (Ondo Tokenized)",
+            "symbol": "SPCXon",
+            "decimals": 18,
+            "logoURI": "https://cdn.ondo.finance/tokens/logos/spcxon_160x160.png",
+            "tags": [
+                "ondo"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Previous PR https://github.com/ondoprotocol/ondo-global-markets-token-list/pull/8 was a little too hasty, I accidentally included assets from pt 2 and assets that are ineligible at this time. This PR should include ONLY the 173 assets currently live in the GM backend + SPCXon.